### PR TITLE
Update ci_cd workflow (#51)

### DIFF
--- a/.github/workflows/ci_cd.yaml
+++ b/.github/workflows/ci_cd.yaml
@@ -1,10 +1,14 @@
 name: CI_CD
-on: [push]
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
 
 jobs:
   CI:
     name: Automated tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     services:
       postgres:
         image: postgres:12.5-alpine
@@ -20,26 +24,29 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - name: Clone the repository
-        uses: actions/checkout@v2
-      - name: Use Node v14.x
-        uses: actions/setup-node@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
         with:
           node-version: 14.15.4
-      - name: Install dependencies
-        run: yarn install
-      - name: Build all projects
-        run: yarn build
-      - name: Run automated tests
-        run: yarn test
-      - name: Report coverage
-        uses: codecov/codecov-action@v1
+      - id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - run: yarn install --prefer-offline
+      - run: yarn build
+      - run: yarn test
+      - uses: codecov/codecov-action@v1
         with:
           fail_ci_if_error: false
 
-  CD-FRONTEND:
+  DEPLOYMENT-FRONTEND:
     name: Deployment - Frontend
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: CI
     if: github.ref == 'refs/heads/master'
     steps:
@@ -47,16 +54,22 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 14.15.4
-      - name: Install dependencies
-        run: yarn install
-      - name: Build frontend project
-        run: yarn wsrun -p @packages/frontend -r build
+      - id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - run: yarn install --prefer-offline
+      - run: yarn wsrun -p @packages/frontend -r build
         env:
           REACT_APP_API_URI: 'https://benard-card-game-api.herokuapp.com'
-      - name: Deploy to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@3.6.2
+      - uses: JamesIves/github-pages-deploy-action@3.6.2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: deployment-frontend
+          BRANCH: live-frontend
           FOLDER: packages/frontend/build
           CLEAN: true


### PR DESCRIPTION
* Trigger workflow on pull_request & merges into master
* Cache yarn packages to reduce the installation duration
* GitHub-Pages now uses the branch `live-frontend`