### PR TITLE
fix: Update context when the Lobby is not found

### DIFF
--- a/packages/backend/src/api/graphql/resolvers/lobby/mutations/createLobby.ts
+++ b/packages/backend/src/api/graphql/resolvers/lobby/mutations/createLobby.ts
@@ -8,7 +8,7 @@ import { Logger } from '../../../../../utils/Logger';
 import { ServiceLocator } from '../../../../../utils/ServiceLocator';
 import { Context } from '../../../Context';
 import { ViewerType } from '../../../entities/ViewerType';
-import { updateLobbyInContext } from '../utils/updateLobbyContext';
+import { updateLobbyInContext } from '../../../utils/updateLobbyContext';
 
 @InputType()
 export class CreateLobbyInput {

--- a/packages/backend/src/api/graphql/resolvers/lobby/mutations/joinLobby.ts
+++ b/packages/backend/src/api/graphql/resolvers/lobby/mutations/joinLobby.ts
@@ -8,7 +8,7 @@ import { Logger } from '../../../../../utils/Logger';
 import { ServiceLocator } from '../../../../../utils/ServiceLocator';
 import { Context } from '../../../Context';
 import { ViewerType } from '../../../entities/ViewerType';
-import { updateLobbyInContext } from '../utils/updateLobbyContext';
+import { updateLobbyInContext } from '../../../utils/updateLobbyContext';
 
 @InputType()
 export class JoinLobbyInput {

--- a/packages/backend/src/api/graphql/resolvers/lobby/mutations/leaveLobby.ts
+++ b/packages/backend/src/api/graphql/resolvers/lobby/mutations/leaveLobby.ts
@@ -3,7 +3,7 @@ import { Logger } from '../../../../../utils/Logger';
 import { ServiceLocator } from '../../../../../utils/ServiceLocator';
 import { Context } from '../../../Context';
 import { ViewerType } from '../../../entities/ViewerType';
-import { updateLobbyInContext } from '../utils/updateLobbyContext';
+import { updateLobbyInContext } from '../../../utils/updateLobbyContext';
 
 export async function leaveLobby(
   serviceLocator: ServiceLocator,

--- a/packages/backend/src/api/graphql/resolvers/viewer/queries/viewerLobby.ts
+++ b/packages/backend/src/api/graphql/resolvers/viewer/queries/viewerLobby.ts
@@ -2,6 +2,7 @@ import { LobbyCore } from '../../../../../core/lib/lobby';
 import { ServiceLocator } from '../../../../../utils/ServiceLocator';
 import { Context } from '../../../Context';
 import { LobbyType } from '../../../entities/LobbyType';
+import { updateLobbyInContext } from '../../../utils/updateLobbyContext';
 
 export async function viewerLobby(
   serviceLocator: ServiceLocator,
@@ -17,6 +18,7 @@ export async function viewerLobby(
 
   const lobby = await lobbyCore.findLobbyById(lobbyId);
   if (!lobby) {
+    await updateLobbyInContext(serviceLocator, context, undefined);
     return undefined;
   }
 

--- a/packages/backend/src/api/graphql/utils/updateLobbyContext.ts
+++ b/packages/backend/src/api/graphql/utils/updateLobbyContext.ts
@@ -1,9 +1,9 @@
-import { CookieSetter } from '../../../../../utils/CookieSetter';
-import { Jwt } from '../../../../../utils/Jwt';
-import { ServiceLocator } from '../../../../../utils/ServiceLocator';
-import { COOKIE_API_TOKEN } from '../../../../constants';
-import { TokenPayload } from '../../../../types/TokenPayload';
-import { Context } from '../../../Context';
+import { CookieSetter } from '../../../utils/CookieSetter';
+import { Jwt } from '../../../utils/Jwt';
+import { ServiceLocator } from '../../../utils/ServiceLocator';
+import { COOKIE_API_TOKEN } from '../../constants';
+import { TokenPayload } from '../../types/TokenPayload';
+import { Context } from '../Context';
 
 export async function updateLobbyInContext(
   serviceLocator: ServiceLocator,


### PR DESCRIPTION
Remove `lobbyId` from coockie context when the corresponding `Lobby` does not exist in DB.